### PR TITLE
NDMF(Modular Avatar) plugin support / GameObject List

### DIFF
--- a/Editor/ShellProtectorEditor.cs
+++ b/Editor/ShellProtectorEditor.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -18,6 +18,7 @@ namespace Shell.Protector
         ShellProtector root = null;
         readonly LanguageManager lang = LanguageManager.GetInstance();
 
+        SerializedProperty game_object_list;
         ReorderableList material_list;
         ReorderableList texture_list;
 
@@ -74,6 +75,8 @@ namespace Shell.Protector
 
             MonoScript monoScript = MonoScript.FromMonoBehaviour(root);
             string script_path = AssetDatabase.GetAssetPath(monoScript);
+
+            game_object_list = serializedObject.FindProperty("game_object_list");
             root.asset_dir = Path.GetDirectoryName(Path.GetDirectoryName(script_path));
 
             material_list = new ReorderableList(serializedObject, serializedObject.FindProperty("material_list"), true, true, true, true);
@@ -231,6 +234,7 @@ namespace Shell.Protector
             GUILayout.Label(Lang("Parameters to be used:") + using_parameter, EditorStyles.wordWrappedLabel);
 
             serializedObject.Update();
+            EditorGUILayout.PropertyField(game_object_list, new GUIContent(Lang("Game Object List")), true);
             material_list.DoLayoutList();
 
             #region Options
@@ -320,7 +324,7 @@ namespace Shell.Protector
                 GUI.enabled = false;
                 GUILayout.Label(Lang("Not enough parameter space!"), red_style);
             }
-            if (material_list.count == 0)
+            if (game_object_list.arraySize == 0 && material_list.count == 0)
                 GUI.enabled = false;
 
             if (GUILayout.Button(Lang("Encrypt!")))

--- a/Scripts/NDMF.meta
+++ b/Scripts/NDMF.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1929a3d9a3aea747bb5e675aa03697e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/NDMF/ShellProtectorNDMFPlugin.cs
+++ b/Scripts/NDMF/ShellProtectorNDMFPlugin.cs
@@ -1,0 +1,24 @@
+#if UNITY_EDITOR
+using nadena.dev.ndmf;
+using Shell.Protector;
+using UnityEngine;
+
+[assembly: ExportsPlugin(typeof(ShellProtectorNDMFPlugin))]
+
+public class ShellProtectorNDMFPlugin : Plugin<ShellProtectorNDMFPlugin>
+{
+    protected override void Configure()
+    {
+        InPhase(BuildPhase.Generating)
+        .BeforePlugin("nadena.dev.modular-avatar")
+        .Run("Encrypting", ctx =>
+        {
+            Debug.Log("Encrypting Shell Protector");
+            if (ctx.AvatarRootObject.TryGetComponent<ShellProtector>(out var shellProtector))
+            {
+                shellProtector.Encrypt(clone: false);
+            }
+        });
+    }
+}
+#endif

--- a/Scripts/NDMF/ShellProtectorNDMFPlugin.cs.meta
+++ b/Scripts/NDMF/ShellProtectorNDMFPlugin.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 999a3a17240db9048b21b3517661c28f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Shell.Protector.asmdef
+++ b/Scripts/Shell.Protector.asmdef
@@ -1,6 +1,11 @@
 {
     "name": "Shell.Protector",
-    "references": ["ThryAssemblyDefinition"],
+    "rootNamespace": "",
+    "references": [
+        "ThryAssemblyDefinition",
+        "nadena.dev.ndmf",
+        "nadena.dev.ndmf.runtime"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Scripts/ShellProtector.cs
+++ b/Scripts/ShellProtector.cs
@@ -21,7 +21,7 @@ using Thry;
 
 namespace Shell.Protector
 {
-    public class ShellProtector : MonoBehaviour
+    public class ShellProtector : MonoBehaviour, IEditorOnly
     {
 [SerializeField]
         List<GameObject> game_object_list = new List<GameObject>();

--- a/Scripts/ShellProtectorTester.cs
+++ b/Scripts/ShellProtectorTester.cs
@@ -3,10 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using VRC.SDKBase;
 
 namespace Shell.Protector
 {
-    public class ShellProtectorTester : MonoBehaviour
+    public class ShellProtectorTester : MonoBehaviour, IEditorOnly
     {
         public string lang = "eng";
         public int lang_idx = 0;


### PR DESCRIPTION
1. NDMF (Modular Avatar)를 적용하여 플레이 시에 자동으로 Encrypt! 버튼을 누른 것 같이 동작하도록 했습니다.

Assembly Definition에 nadena.dev.ndmf에 대한 종속성이 생겼으므로 확인해주세요. Modular Avatar가 설치 안돼있으면 오류가 날 것 같은데 어떻게 할 지 모르겠네요. 이 부분은 만약 직접 해결하는게 간단하시다면 직접 해주시고 아니라면 제가 수정해보겠습니다. 아예 별도 유니티 패키지로 제공하는게 나을수도 있을 것 같네요

2. Shell Protector 컴포넌트에 Game Object List를 추가했습니다. 매터리얼을 지정하는 것보다 이렇게 하는게 더 편한 사람도 있을 것 같아서 기능을 추가해봤습니다.