### PR TITLE
동기화 파라미터 개수 설정 / 파라미터 저장

### DIFF
--- a/Editor/ShellProtectorEditor.cs
+++ b/Editor/ShellProtectorEditor.cs
@@ -29,6 +29,7 @@ namespace Shell.Protector
         SerializedProperty algorithm;
         SerializedProperty key_size;
         SerializedProperty key_size_idx;
+        SerializedProperty sync_size;
         SerializedProperty animation_speed;
         SerializedProperty delete_folders;
         SerializedProperty parameter_multiplexing;
@@ -108,8 +109,9 @@ namespace Shell.Protector
             algorithm = serializedObject.FindProperty("algorithm");
             key_size = serializedObject.FindProperty("key_size");
             key_size_idx = serializedObject.FindProperty("key_size_idx");
+            sync_size = serializedObject.FindProperty("sync_size");
             animation_speed = serializedObject.FindProperty("animation_speed");
-            delete_folders = serializedObject.FindProperty("delete_folders"); 
+            delete_folders = serializedObject.FindProperty("delete_folders");
             parameter_multiplexing = serializedObject.FindProperty("parameter_multiplexing");
             bUseSmallMipTexture = serializedObject.FindProperty("bUseSmallMipTexture");
             bPreserveMMD = serializedObject.FindProperty("bPreserveMMD");
@@ -229,22 +231,10 @@ namespace Shell.Protector
             int using_parameter = (key_size.intValue * 8);
             if(parameter_multiplexing.boolValue == true)
             {
-                int keys = key_size.intValue;
-                switch(keys)
-                {
-                    case 4:
-                        using_parameter = 8 + 3;
-                        break;
-                    case 8:
-                        using_parameter = 8 + 4;
-                        break;
-                    case 12:
-                        using_parameter = 8 + 5;
-                        break;
-                    case 16:
-                        using_parameter = 8 + 5;
-                        break;
-                }
+                int lock_size = 1;
+                int pkey_count = sync_size.intValue;
+                int switch_count = ShellProtector.GetRequiredSwitchCount(key_size.intValue, sync_size.intValue);
+                using_parameter = switch_count + lock_size + pkey_count * 8;
             }
             GUILayout.Label(Lang("Parameters to be used:") + using_parameter, EditorStyles.wordWrappedLabel);
 
@@ -281,6 +271,21 @@ namespace Shell.Protector
                     case 4:
                         key_size.intValue = 16;
                         break;
+                }
+
+                var sync_size_value = sync_size.intValue;
+                int sync_size_index = 0;
+                int[] sync_size_caldidate = { 1, 2, 4};
+                string[] selectable_values = { "1", "2", "4" };
+                for (int i = 0; i < sync_size_caldidate.Length; i++)
+                    if (sync_size_caldidate[i] == sync_size_value)
+                        sync_size_index = i;
+
+                if(key_size.intValue > 0)
+                {
+                    GUILayout.Label(Lang("Sync speed"), EditorStyles.boldLabel);
+                    sync_size_index = EditorGUILayout.Popup(sync_size_index, selectable_values, GUILayout.Width(100));
+                    sync_size.intValue = sync_size_caldidate[sync_size_index];
                 }
 
                 GUILayout.Label(Lang("Encrytion algorithm"), EditorStyles.boldLabel);
@@ -399,7 +404,7 @@ namespace Shell.Protector
             if (game_object_list.count == 0 && material_list.count == 0)
                 GUI.enabled = false;
 
-            
+
 #if MODULAR
             if (GUILayout.Button(Lang("Manual Encrypt!")))
 #else

--- a/Editor/ShellProtectorEditor.cs
+++ b/Editor/ShellProtectorEditor.cs
@@ -232,9 +232,8 @@ namespace Shell.Protector
             if(parameter_multiplexing.boolValue == true)
             {
                 int lock_size = 1;
-                int pkey_count = sync_size.intValue;
                 int switch_count = ShellProtector.GetRequiredSwitchCount(key_size.intValue, sync_size.intValue);
-                using_parameter = switch_count + lock_size + pkey_count * 8;
+                using_parameter = switch_count + lock_size + sync_size.intValue * 8;
             }
             GUILayout.Label(Lang("Parameters to be used:") + using_parameter, EditorStyles.wordWrappedLabel);
 

--- a/Runtime/Scripts/AnimatorManager.cs
+++ b/Runtime/Scripts/AnimatorManager.cs
@@ -254,7 +254,7 @@ namespace Shell.Protector
             if (optimize)
             {
                 for(int i = 0; i < sync_size; i++)
-                    anim.AddParameter("pkey_sync" + i, AnimatorControllerParameterType.Float);
+                    anim.AddParameter(ParameterManager.GetPKeySyncParameterName(i), AnimatorControllerParameterType.Float);
                 anim.AddParameter("encrypt_lock", AnimatorControllerParameterType.Bool);
                 int switch_count = ShellProtector.GetRequiredSwitchCount(key_length, sync_size);
                 for (int i = 0; i < switch_count; ++i)
@@ -350,7 +350,7 @@ namespace Shell.Protector
                     {
                         type = VRC.SDKBase.VRC_AvatarParameterDriver.ChangeType.Copy,
                         name = "pkey" + (i * sync_size + j),
-                        source = "pkey_sync" + j
+                        source = ParameterManager.GetPKeySyncParameterName(j)
                     };
                     behaviour.parameters.Add(behaviour_param);
                 }

--- a/Runtime/Scripts/AnimatorManager.cs
+++ b/Runtime/Scripts/AnimatorManager.cs
@@ -195,10 +195,8 @@ namespace Shell.Protector
             {
                 BlendTree tree_key = new BlendTree();
                 tree_key.name = "key" + i;
-                tree_key.blendType = BlendTreeType.Direct;
-                tree_key.blendParameter = "key_weight";
                 tree_key.blendType = BlendTreeType.Simple1D;
-                tree_key.blendParameter = "pkey" + i;
+                tree_key.blendParameter = ParameterManager.GetPKeyParameterName(i);
                 tree_key.useAutomaticThresholds = false;
 
                 Motion motion0 = AssetDatabase.LoadAssetAtPath(Path.Combine(animation_dir, "key" + (i + offset) + ".anim"), typeof(AnimationClip)) as AnimationClip;
@@ -232,10 +230,10 @@ namespace Shell.Protector
 
         private static void AddTransition(AnimatorStateTransition transition, int keyLength, int syncSize, int idx)
         {
-            transition.AddCondition(AnimatorConditionMode.IfNot, 0, "encrypt_lock");
+            transition.AddCondition(AnimatorConditionMode.IfNot, 0, ParameterManager.GetSyncLockParameterName());
             AnimatorConditionMode[] switchConditions = GetSwitchConditions(ShellProtector.GetRequiredSwitchCount(keyLength, syncSize), idx);
             for (int i = 0; i < switchConditions.Length; ++i)
-                transition.AddCondition(switchConditions[i], 0, "encrypt_switch" + i);
+                transition.AddCondition(switchConditions[i], 0, ParameterManager.GetSyncSwitchParameterName(i));
         }
         public static void AddParameter(AnimatorController anim, int key_length, int sync_size, bool optimize)
         {
@@ -249,16 +247,16 @@ namespace Shell.Protector
             anim.AddParameter(new AnimatorControllerParameter() { defaultFloat = 1.0f, name = "key_weight", type = AnimatorControllerParameterType.Float });
 
             for (int i = 0; i < key_length; ++i)
-                anim.AddParameter("pkey" + i, AnimatorControllerParameterType.Float);
+                anim.AddParameter(ParameterManager.GetPKeyParameterName(i), AnimatorControllerParameterType.Float);
 
             if (optimize)
             {
                 for(int i = 0; i < sync_size; i++)
                     anim.AddParameter(ParameterManager.GetPKeySyncParameterName(i), AnimatorControllerParameterType.Float);
-                anim.AddParameter("encrypt_lock", AnimatorControllerParameterType.Bool);
+                anim.AddParameter(ParameterManager.GetSyncLockParameterName(), AnimatorControllerParameterType.Bool);
                 int switch_count = ShellProtector.GetRequiredSwitchCount(key_length, sync_size);
                 for (int i = 0; i < switch_count; ++i)
-                    anim.AddParameter("encrypt_switch" + i, AnimatorControllerParameterType.Bool);
+                    anim.AddParameter(ParameterManager.GetSyncSwitchParameterName(i), AnimatorControllerParameterType.Bool);
             }
         }
         public static void AddKeyLayer(AnimatorController anim, string animation_dir, int key_length, int sync_size, float speed = 10.0f, bool optimize = false)
@@ -337,7 +335,7 @@ namespace Shell.Protector
             transition.exitTime = 0;
             transition.duration = 0;
             transition.hasExitTime = false;
-            transition.AddCondition(AnimatorConditionMode.If, 0, "encrypt_lock");
+            transition.AddCondition(AnimatorConditionMode.If, 0, ParameterManager.GetSyncLockParameterName());
 
             for (int i = 0; i < key_length / sync_size; ++i)
             {
@@ -349,7 +347,7 @@ namespace Shell.Protector
                     var behaviour_param = new VRCAvatarParameterDriver.Parameter
                     {
                         type = VRC.SDKBase.VRC_AvatarParameterDriver.ChangeType.Copy,
-                        name = "pkey" + (i * sync_size + j),
+                        name = ParameterManager.GetPKeyParameterName(i * sync_size + j),
                         source = ParameterManager.GetPKeySyncParameterName(j)
                     };
                     behaviour.parameters.Add(behaviour_param);

--- a/Runtime/Scripts/AnimatorManager.cs
+++ b/Runtime/Scripts/AnimatorManager.cs
@@ -247,12 +247,15 @@ namespace Shell.Protector
                 type = AnimatorControllerParameterType.Float
             });
 
-            anim.AddParameter(new AnimatorControllerParameter
+            if (anim.parameters.All(p => p.name != ParameterManager.GetIsLocalName()))
             {
-                defaultBool = true,
-                name = ParameterManager.GetSyncEnabledName(),
-                type = AnimatorControllerParameterType.Bool
-            });
+                anim.AddParameter(new AnimatorControllerParameter
+                {
+                    defaultBool = false,
+                    name = ParameterManager.GetIsLocalName(),
+                    type = AnimatorControllerParameterType.Bool
+                });
+            }
 
             for (var i = 0; i < keyLength; ++i)
                 anim.AddParameter(ParameterManager.GetKeyName(i), AnimatorControllerParameterType.Float);
@@ -317,7 +320,7 @@ namespace Shell.Protector
 
         private static void AddSyncEnabledCondition(AnimatorStateTransition transition)
         {
-            transition.AddCondition(AnimatorConditionMode.If, 0, ParameterManager.GetSyncEnabledName());
+            transition.AddCondition(AnimatorConditionMode.If, 0, ParameterManager.GetIsLocalName());
         }
 
         private static void AddMuxLayer(AnimatorController anim, int keyLength, int syncSize, float unlockDelay, float interval, float delay)

--- a/Runtime/Scripts/ParameterManager.cs
+++ b/Runtime/Scripts/ParameterManager.cs
@@ -19,6 +19,12 @@ public static class ParameterManager
         return tmp;
     }
 
+    public static string GetPKeySyncParameterName(int index)
+    {
+        if (index == 0) return "pkey"; // For backward compatibility
+        return "pkey_sync" + index;
+    }
+
     public static VRCExpressionParameters AddKeyParameter(VRCExpressionParameters vrc_parameters, int key_length, int sync_size,  bool use_multiplexing = false)
     {
         VRCExpressionParameters result = ScriptableObject.CreateInstance<VRCExpressionParameters>();
@@ -59,7 +65,7 @@ public static class ParameterManager
             {
                 var para = new VRCExpressionParameters.Parameter
                 {
-                    name = $"pkey_sync{i}",
+                    name = GetPKeySyncParameterName(i),
                     saved = true,
                     networkSynced = true,
                     valueType = VRCExpressionParameters.ValueType.Float,

--- a/Runtime/Scripts/ParameterManager.cs
+++ b/Runtime/Scripts/ParameterManager.cs
@@ -15,23 +15,14 @@ public static class ParameterManager
     }
     public static string GetKeyName(int index) => Prefix + "key" + index;
     public static string GetSavedKeyName(int index) => Prefix + "saved_key" + index;
-    public static string GetSyncEnabledName() => Prefix + "sync_enabled";
     public static string GetSyncSwitchName(int index) => Prefix + "sync_switch" + index;
     public static string GetSyncLockName() => Prefix + "sync_lock";
+    public static string GetIsLocalName() => "IsLocal";
 
 
     public static VRCExpressionParameters AddKeyParameter(VRCExpressionParameters vrcParameters, int keyLength, int syncSize,  bool useMultiplexing)
     {
         var parameters = new List<VRCExpressionParameters.Parameter>();
-
-        parameters.Add(new VRCExpressionParameters.Parameter
-        {
-            name = GetSyncEnabledName(),
-            saved = false,
-            networkSynced = false,
-            valueType = VRCExpressionParameters.ValueType.Bool,
-            defaultValue = 1.0f
-        });
 
         if (useMultiplexing == false)
         {

--- a/Runtime/Scripts/ParameterManager.cs
+++ b/Runtime/Scripts/ParameterManager.cs
@@ -7,19 +7,31 @@ using VRC.SDK3.Avatars.ScriptableObjects;
 
 public static class ParameterManager
 {
-    public static string GetPKeySyncParameterName(int index)
+    private const string Prefix = "SHELL_PROTECTOR_";
+    public static string GetSyncedKeyNAme(int index)
     {
-        if (index == 0) return "pkey"; // For backward compatibility
-        return "pkey_sync" + index;
+        if (index == 0) return "pkey"; // For backward compatibility (before commit e8080de)
+        return Prefix + "synced_key" + index;
     }
-    public static string GetPKeyParameterName(int index) => "pkey" + index;
-    public static string GetSyncSwitchParameterName(int index) => "encrypt_switch" + index;
-    public static string GetSyncLockParameterName() => "encrypt_lock";
+    public static string GetKeyName(int index) => Prefix + "key" + index;
+    public static string GetSavedKeyName(int index) => Prefix + "saved_key" + index;
+    public static string GetSyncEnabledName() => Prefix + "sync_enabled";
+    public static string GetSyncSwitchName(int index) => Prefix + "sync_switch" + index;
+    public static string GetSyncLockName() => Prefix + "sync_lock";
 
 
     public static VRCExpressionParameters AddKeyParameter(VRCExpressionParameters vrcParameters, int keyLength, int syncSize,  bool useMultiplexing)
     {
         var parameters = new List<VRCExpressionParameters.Parameter>();
+
+        parameters.Add(new VRCExpressionParameters.Parameter
+        {
+            name = GetSyncEnabledName(),
+            saved = false,
+            networkSynced = false,
+            valueType = VRCExpressionParameters.ValueType.Bool,
+            defaultValue = 1.0f
+        });
 
         if (useMultiplexing == false)
         {
@@ -27,7 +39,7 @@ public static class ParameterManager
             {
                 parameters.Add(new VRCExpressionParameters.Parameter
                 {
-                    name = GetPKeyParameterName(i),
+                    name = GetKeyName(i),
                     saved = true,
                     networkSynced = true,
                     valueType = VRCExpressionParameters.ValueType.Float,
@@ -39,7 +51,7 @@ public static class ParameterManager
         {
             parameters.Add(new VRCExpressionParameters.Parameter
             {
-                name = GetSyncLockParameterName(),
+                name = GetSyncLockName(),
                 saved = true,
                 networkSynced = true,
                 valueType = VRCExpressionParameters.ValueType.Bool,
@@ -50,7 +62,7 @@ public static class ParameterManager
             {
                 parameters.Add(new VRCExpressionParameters.Parameter
                 {
-                    name = GetPKeySyncParameterName(i),
+                    name = GetSyncedKeyNAme(i),
                     saved = true,
                     networkSynced = true,
                     valueType = VRCExpressionParameters.ValueType.Float,
@@ -62,7 +74,7 @@ public static class ParameterManager
             {
                 parameters.Add(new VRCExpressionParameters.Parameter
                 {
-                    name = GetSyncSwitchParameterName(i),
+                    name = GetSyncSwitchName(i),
                     saved = true,
                     networkSynced = true,
                     valueType = VRCExpressionParameters.ValueType.Bool,
@@ -74,8 +86,17 @@ public static class ParameterManager
             {
                 parameters.Add(new VRCExpressionParameters.Parameter
                 {
-                    name = GetPKeyParameterName(i),
+                    name = GetKeyName(i),
                     saved = false,
+                    networkSynced = false,
+                    valueType = VRCExpressionParameters.ValueType.Float,
+                    defaultValue = 0.0f
+                });
+
+                parameters.Add(new VRCExpressionParameters.Parameter
+                {
+                    name = GetSavedKeyName(i),
+                    saved = true,
                     networkSynced = false,
                     valueType = VRCExpressionParameters.ValueType.Float,
                     defaultValue = 0.0f

--- a/Runtime/Scripts/ShellProtector.cs
+++ b/Runtime/Scripts/ShellProtector.cs
@@ -11,6 +11,7 @@ using VRC.SDK3.Avatars.Components;
 using System.Linq;
 using VRC.SDKBase;
 using UnityEditor.Animations;
+using UnityEngine.Serialization;
 
 #if MODULAR
 using nadena.dev.modular_avatar.core;
@@ -90,6 +91,7 @@ namespace Shell.Protector
         [SerializeField] int algorithm = 1;
         [SerializeField] int key_size_idx = 3;
         [SerializeField] int key_size = 12;
+        [SerializeField] int sync_size = 1;
         [SerializeField] float animation_speed = 5.0f;
         [SerializeField] bool delete_folders = true;
         [SerializeField] bool parameter_multiplexing = false;
@@ -733,7 +735,7 @@ namespace Shell.Protector
 
             ///////////////////////parameter////////////////////
             var av3 = avatar.GetComponent<VRC.SDK3.Avatars.Components.VRCAvatarDescriptor>();
-            av3.expressionParameters = ParameterManager.AddKeyParameter(av3.expressionParameters, key_size, parameter_multiplexing);
+            av3.expressionParameters = ParameterManager.AddKeyParameter(av3.expressionParameters, key_size, sync_size, parameter_multiplexing);
             AssetDatabase.CreateAsset(av3.expressionParameters, Path.Combine(avatarDir, av3.expressionParameters.name + ".asset"));
             ////////////////////////////////////////////////////
             SetMaterialFallbackValue(avatar, true);
@@ -783,7 +785,7 @@ namespace Shell.Protector
             meshes.CopyTo(mesh_array);
             AnimatorManager.CreateKeyAniamtions(Path.Combine(asset_dir, "Animations"), animation_dir, mesh_array);
             var fallbackAnim = AnimatorManager.CreateFallbackAniamtions(Path.Combine(asset_dir, "Animations", "FallbackOff.anim"), animation_dir, mesh_array);
-            AnimatorManager.AddKeyLayer(fx, animation_dir, key_size, animation_speed, parameter_multiplexing);
+            AnimatorManager.AddKeyLayer(fx, animation_dir, key_size, sync_size, animation_speed, parameter_multiplexing);
             AnimatorManager.AddFallbackLayer(fx, fallbackAnim, fallbackTime);
 
             AssetDatabase.SaveAssets();
@@ -1086,6 +1088,12 @@ namespace Shell.Protector
             }
             history.LoadData();
             return history.IsEncryptedBefore(shader);
+        }
+
+        public static int GetRequiredSwitchCount(int key_length, int sync_size)
+        {
+            key_length /= sync_size;
+            return Mathf.CeilToInt(Mathf.Log(key_length, 2));
         }
     }
 }


### PR DESCRIPTION
cc8ecdf 동기화 파라미터 (pkey) 개수(sync size)를 1, 2, 4 개 중 하나로 설정하여 동기화 속도를 올릴 수 있도록 했습니다. pkey의 이름은 하위호환을 위해 pkey, pkey_sync1, pkey_sync2, pkey_sync3 과 같이 명명되므로 sync size가 1인 경우 현재 버전의 OSC로도 동작합니다

4cbc21a 멀티플렉싱 상황에서도 키를 아바타에 저장할 수 있게 했습니다. 아바타의 애니메이터를 통해 Mux/Demux를 수행합니다. OSC 프로그램이 Demux를 수행하지 않고 아바타의 각 saved 파라미터에 키를 쓰도록 수정해야 합니다. 파라미터 이름을 SHELL_PROTECTOR_saved_key0 과 같이 수정하였으니 참고바랍니다 (파라미터 이름이 ParameterManager.cs에 메서드로 정의됨)

Visual Studio 세팅이 어려워 OSC는 다른 분이 업데이트해주시면 좋겠습니다. 4cbc21a의 경우 OSC에 대한 하위 호환성이 깨지기 때문에 이를 리뷰하고 병합 부탁드립니다.

closes #25 